### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "dcos-infrastructure" {
 | bootstrap_disk_size | Bootstrap node disk size (gb) | string | `` | no |
 | bootstrap_disk_type | Bootstrap node disk type. | string | `` | no |
 | bootstrap_image | [BOOTSTRAP] Image to be used | string | `` | no |
-| bootstrap_machine_type | Bootstrap node machine type | string | `` | no |
+| bootstrap_machine_type | [BOOTSTRAP] Machine type | string | `` | no |
 | bootstrap_public_ssh_key_path | Bootstrap Node Public SSH Key | string | `` | no |
 | bootstrap_ssh_user | Bootstrap node SSH User | string | `` | no |
 | cluster_name | Name of the DC/OS cluster | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module creates typical DS/OS infrastructure in GCP.
 ```hcl
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/gcp"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@
  * ```hcl
  * module "dcos-infrastructure" {
  *   source  = "dcos-terraform/infrastructure/gcp"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
  *

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "bootstrap_disk_type" {
 }
 
 variable "bootstrap_machine_type" {
-  description = "Bootstrap node machine type"
+  description = "[BOOTSTRAP] Machine type"
   default     = ""
 }
 


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2