### PR TITLE
main/readme: pinned this version to gcp 2.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module creates typical DS/OS infrastructure in GCP.
 ```hcl
 module "dcos-infrastructure" {
   source  = "dcos-terraform/infrastructure/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module "compute-firewall" {
 
 module "dcos-forwarding-rules" {
   source  = "dcos-terraform/compute-forwarding-rule-dcos/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"
@@ -81,7 +81,7 @@ module "dcos-forwarding-rules" {
 
 module "bootstrap" {
   source  = "dcos-terraform/bootstrap/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"
@@ -106,7 +106,7 @@ module "bootstrap" {
 
 module "masters" {
   source  = "dcos-terraform/masters/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"
@@ -132,7 +132,7 @@ module "masters" {
 
 module "private_agents" {
   source  = "dcos-terraform/private-agents/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"
@@ -158,7 +158,7 @@ module "private_agents" {
 
 module "public_agents" {
   source  = "dcos-terraform/public-agents/gcp"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   providers = {
     google = "google"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@
  * ```hcl
  * module "dcos-infrastructure" {
  *   source  = "dcos-terraform/infrastructure/gcp"
- *   version = "~> 0.1.0"
+ *   version = "~> 0.2.0"
  *
  *   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
  *
@@ -31,7 +31,9 @@ data "null_data_source" "lb_rules" {
   }
 }
 
-provider "google" {}
+provider "google" {
+  version = "~> 2.0"
+}
 
 data "google_compute_zones" "available" {}
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-48802

As GCP update the latest version of the provider, we now require to update the templates so that it can select the proper version associated with the change.