### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ module "compute-firewall" {
   admin_ips                      = ["${var.admin_ips}"]
   internal_subnets               = "${local.internal_subnets}"
   public_agents_additional_ports = ["${var.public_agents_additional_ports}"]
+  adminrouter_grpc_proxy_port    = "${var.adminrouter_grpc_proxy_port}"
 }
 
 module "dcos-forwarding-rules" {
@@ -85,6 +86,7 @@ module "dcos-forwarding-rules" {
   public_agents_additional_rules = ["${data.null_data_source.lb_rules.*.outputs}"]
   disable_masters                = "${var.forwarding_rule_disable_masters}"
   disable_public_agents          = "${var.forwarding_rule_disable_public_agents}"
+  adminrouter_grpc_proxy_port    = "${var.adminrouter_grpc_proxy_port}"
 
   labels = "${var.labels}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -244,3 +244,8 @@ variable "forwarding_rule_disable_public_agents" {
   description = "Do not create forwarding rules for public agents. ( Needs to be true when num_public_agents is 0 )"
   default     = false
 }
+
+variable "adminrouter_grpc_proxy_port" {
+    description = ""
+    default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476